### PR TITLE
update base

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ JwtHeaders | Map used to inject JWT payload fields as HTTP request headers.
 OpaHeaders | Map used to inject OPA result fields as HTTP request headers. Populated if request is allowed by OPA. Only 1st level keys from OPA document are supported.
 OpaResponseHeaders | Map used to inject OPA result fields as HTTP response headers. Populated if OPA response has `OpaAllowField` present, regardless of value. Only 1st level keys from OPA document are supported.
 OpaHttpStatusField | Field in OPA JSON result, which contains int or string HTTP status code that will be returned in case of disallowed OPA response. Accepted range is >= 300 and < 600. Only 1st level keys from OPA document are supported.
-JwtCookieKey | Name of the cookie to extract JWT if not found in `Authorization` header.
-JwtQueryKey | Name of the query parameter to extract JWT if not found in `Authorization` header or in the specified cookie.
+JwtCookieKey | (Deprecated, use JwtSources)Name of the cookie to extract JWT if not found in `Authorization` header.
+JwtQueryKey | (Deprecated, use JwtSources) Name of the query parameter to extract JWT if not found in `Authorization` header or in the specified cookie.
+JwtSources | Ordered List of sources [bearer, header, query, cookie] of the JWT. config format is a list of maps e.g. [{type: bearer, key: Authorization}, {type: query, key, jwt}]
+
 
 ### Example configuration
 
@@ -98,7 +100,11 @@ spec:
       OpaResponseHeaders:
         X-Allowed: allow
       OpaHttpStatusField: allow_status_code
-      JwtCookieKey: jwt
+      JwtSources:
+        - type: bearer
+          key: Authorization
+        - type: cookie
+          key: jwt
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ OpaDebugMode | Set the opa response in the http response body when the request i
 PayloadFields | The field-name in the JWT payload that are required (e.g. `exp`). Multiple field names may be specified (string array)
 Required | Is `Authorization` header with JWT token required for every request.
 Keys | Used to validate JWT signature. Multiple keys are supported. Allowed values include certificates, public keys, symmetric keys. In case the value is a valid URL, the plugin will fetch keys from the JWK endpoint.
+ForceRefreshKeys | Force fetching keys from JWKS service when the key of current JWT token is not found. If set false, keys will only be refreshed every 15 minutes by default.
 Alg | Used to verify which PKI algorithm is used in the JWT.
 JwksHeaders | Map used to add headers to a JWKS request (e.g. credentials for a 3rd party JWKS service).
 JwtHeaders | Map used to inject JWT payload fields as HTTP request headers.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # traefik-jwt-plugin ![Build](https://github.com/traefik-plugins/traefik-jwt-plugin/actions/workflows/build.yaml/badge.svg)
 
+> [!IMPORTANT]
+> This project is looking for maintainers. Please comment in [this issue](https://github.com/traefik-plugins/traefik-jwt-plugin/issues/82)
+
 Traefik plugin for verifying JSON Web Tokens (JWT). Supports public keys, certificates or JWKS endpoints.
 Supports RSA, ECDSA and symmetric keys. Supports Open Policy Agent (OPA) for additional authorization checks.
 

--- a/jwt.go
+++ b/jwt.go
@@ -159,7 +159,7 @@ type PayloadInput struct {
 	Headers    map[string][]string    `json:"headers"`
 	JWTHeader  JwtHeader              `json:"tokenHeader"`
 	JWTPayload map[string]interface{} `json:"tokenPayload"`
-	Body       map[string]interface{} `json:"body,omitempty"`
+	Body       interface{}            `json:"body,omitempty"`
 	Form       url.Values             `json:"form,omitempty"`
 }
 

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -121,7 +121,7 @@ func TestServeOPAWithBody(t *testing.T) {
 		contentType    string
 		body           string
 		allowed        bool
-		expectedBody   map[string]interface{}
+		expectedBody   interface{}
 		expectedForm   url.Values
 		expectedStatus int
 		drainBody      bool
@@ -141,6 +141,28 @@ func TestServeOPAWithBody(t *testing.T) {
 			expectedBody: map[string]interface{}{
 				"killroy": "washere",
 			},
+			expectedStatus: http.StatusOK,
+			drainBody:      true,
+		},
+		{
+			name:        "jsonArray",
+			method:      "POST",
+			contentType: "application/json",
+			body:        `[ "killroy", "washere" ]`,
+			allowed:     true,
+			expectedBody: []interface{}{
+				"killroy", "washere",
+			},
+			expectedStatus: http.StatusOK,
+			drainBody:      true,
+		},
+		{
+			name:           "jsonLiteral",
+			method:         "POST",
+			contentType:    "application/json",
+			body:           `"killroy"`,
+			allowed:        true,
+			expectedBody:   "killroy",
 			expectedStatus: http.StatusOK,
 			drainBody:      true,
 		},


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Added configurable JWT token source order via `JwtSources`
  - Supports bearer, header, cookie, and query sources
  - Deprecated `JwtCookieKey` and `JwtQueryKey` in favor of `JwtSources`

- Implemented force-refresh of JWKS keys when JWT `kid` not found
  - Added `ForceRefreshKeys` config option
  - Prevented thread leaks by canceling background refresh on config reload

- Added support for JSON bodies of type array and literals

- Added audience (`aud`) claim validation in JWT payload

- Updated and expanded tests for new features and bug fixes

- Updated documentation for new configuration options and usage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jwt.go</strong><dd><code>Major enhancements: JWT source config, JWKS refresh, audience </code><br><code>validation</code></dd></summary>
<hr>

jwt.go

<li>Introduced <code>JwtSources</code> config for flexible JWT extraction order<br> <li> Added <code>ForceRefreshKeys</code> to trigger JWKS refresh if <code>kid</code> not found<br> <li> Implemented audience (<code>aud</code>) claim validation logic<br> <li> Improved thread safety and background refresh cancellation<br> <li> Enhanced JSON body parsing to support arrays and literals<br> <li> Refactored token extraction and verification logic


</details>


  </td>
  <td><a href="https://github.com/julep-ai/traefik-jwt-plugin/pull/1/files#diff-5e3b638232aa08473d7ebbb49c995075a7e7200d9589b1ca7f5b67eb98d38fbe">+168/-30</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jwt_test.go</strong><dd><code>Expanded tests for new JWT config and validation features</code></dd></summary>
<hr>

jwt_test.go

<li>Added tests for <code>JwtSources</code> header/cookie/query extraction order<br> <li> Added tests for JWKS force-refresh and background refresh cancellation<br> <li> Added tests for audience claim validation (string, array, invalid <br>cases)<br> <li> Added tests for JSON body parsing (array, literal)


</details>


  </td>
  <td><a href="https://github.com/julep-ai/traefik-jwt-plugin/pull/1/files#diff-bb6f1fede3f7c5aba7d6f2bc166273856fe965d7e1d5f49ee476ee7243cf4042">+229/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Updated documentation for new JWT config options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Documented <code>JwtSources</code> and <code>ForceRefreshKeys</code> configuration options<br> <li> Marked <code>JwtCookieKey</code> and <code>JwtQueryKey</code> as deprecated<br> <li> Updated example configuration to use new options


</details>


  </td>
  <td><a href="https://github.com/julep-ai/traefik-jwt-plugin/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances JWT plugin with `JwtSources` for token extraction, `ForceRefreshKeys` for key management, and audience claim validation, along with updated tests and configuration.
> 
>   - **Behavior**:
>     - Introduces `JwtSources` in `jwt.go` to specify JWT extraction order from bearer, header, query, and cookie.
>     - Adds `ForceRefreshKeys` option in `jwt.go` to force key fetching from JWKS if the current JWT key is not found.
>     - Implements audience (`aud`) claim validation in `CheckToken()` in `jwt.go`.
>   - **Configuration**:
>     - Deprecates `JwtCookieKey` and `JwtQueryKey` in favor of `JwtSources` in `README.md` and `jwt.go`.
>     - Updates example configuration in `README.md` to use `JwtSources`.
>   - **Key Management**:
>     - Adds `forceRefreshKeys()` and modifies `BackgroundRefresh()` in `jwt.go` to handle key fetching and refreshing.
>     - Synchronizes key access with `keysLock` in `jwt.go`.
>   - **Testing**:
>     - Adds tests for `JwtSources` and `ForceRefreshKeys` in `jwt_test.go`.
>     - Includes tests for audience claim validation in `jwt_test.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Ftraefik-jwt-plugin&utm_source=github&utm_medium=referral)<sup> for 94d0c46112fcf6a941f9aeb7ab2cef2f2c71a542. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->